### PR TITLE
plugins: mac: support newer mac API version

### DIFF
--- a/src/plugins/mac/mac.cpp
+++ b/src/plugins/mac/mac.cpp
@@ -210,8 +210,12 @@ xmms_mac_get_media_info (xmms_xform_t *xform)
 				gchar *name;
 
 				field_name = pTagField->GetFieldName ();
-				name = (gchar *)GetUTF8FromUTF16 (field_name);
 
+#if MAC_DLL_INTERFACE_VERSION_NUMBER >= 1000
+				name = (gchar *)CAPECharacterHelper::GetUTF8FromUTF16 (field_name);
+#else
+				name = (gchar *)GetUTF8FromUTF16 (field_name);
+#endif
 				memset (field_value, 0, 255);
 				int size = 255;
 				p_ape_tag->GetFieldString (field_name, (char *)field_value, &size, TRUE);

--- a/src/plugins/mac/source_adapter.h
+++ b/src/plugins/mac/source_adapter.h
@@ -38,7 +38,13 @@ public:
 	~CSourceAdapter () {};
 
 	// open / close
-	int Open (const wchar_t * pName) { return ERROR_SUCCESS; }
+#if MAC_DLL_INTERFACE_VERSION_NUMBER >= 1000
+	int Open (const wchar_t * pName, BOOL bOpenReadOnly = FALSE)
+#else
+	int Open (const wchar_t * pName)
+#endif
+	{ return ERROR_SUCCESS; }
+
 	int Close () { return ERROR_SUCCESS; }
 
 	// read / write


### PR DESCRIPTION
The API version 1000 was taken from my monkeysaudio include files without much research, as the sources and history of the package are too painful to retrieve.