### PR TITLE
waftools/man.py: add support for SOURCE_DATE_EPOCH

### DIFF
--- a/waftools/man.py
+++ b/waftools/man.py
@@ -14,7 +14,12 @@ def gzip_func(task):
     try:
         input = open(infile, 'rb')
         outf = open(outfile, 'wb')
-        output = gzip.GzipFile(os.path.basename(infile), fileobj=outf)
+        # Allow building deterministic manpages:
+        #   https://reproducible-builds.org/docs/source-date-epoch/
+        mtime = os.environ.get('SOURCE_DATE_EPOCH')
+        if mtime:
+            mtime = int(mtime)
+        output = gzip.GzipFile(os.path.basename(infile), fileobj=outf, mtime=mtime)
         output.write(input.read())
     finally:
         if input:


### PR DESCRIPTION
When packaging xmms2 for NixOS I noticed single non-deterministic
file: xmms2 manpage. Let's allow distributions to override manpage
timestamp with standard SOURCE_DATE_EPOCH environment variable.