### PR TITLE
OTHER: wcript: port 'check_cc()' to 'fragment='

### DIFF
--- a/src/clients/lib/ruby/wscript
+++ b/src/clients/lib/ruby/wscript
@@ -52,7 +52,16 @@ def configure(conf):
     conf.check_ruby_version((1,8,0))
     conf.check_ruby_ext_devel()
 
-    conf.check_cc(function_name="rb_protect_inspect", header_name="ruby.h",
+    # TODO: port from rb_protect_inspect() to rb_exec_recursive():
+    #    https://github.com/ruby/ruby/commit/70bbad3cfd5a692c8e78ccf750eed3f1c7f186db
+    fragment = """
+    #include <ruby.h>
+    int main(void) {
+        rb_protect_inspect(0,0,0);
+        return 0;
+    }
+    """
+    conf.check_cc(fragment=fragment, header_name="ruby.h",
             uselib="RUBYEXT", mandatory=False)
 
     prefix = os.path.commonprefix([conf.env.ARCHDIR_RUBY, conf.env.PREFIX])

--- a/src/clients/lib/xmmsclient/wscript
+++ b/src/clients/lib/xmmsclient/wscript
@@ -46,7 +46,13 @@ def configure(conf):
     conf.env.XMMS_PKGCONF_FILES.append(("xmms2-client", "-lxmmsclient"))
 
     try:
-        conf.check_cc(function_name="semtimedop",
+        semtimedop_fragment = """
+        #include <sys/sem.h>
+        int main(void) {
+            return semtimedop(0,0,0,0);
+        }
+        """
+        conf.check_cc(fragment=semtimedop_fragment,
                 header_name=["sys/types.h", "sys/ipc.h", "sys/sem.h"],
                 defines=["_GNU_SOURCE=1"])
     except Errors.ConfigurationError:

--- a/src/clients/mdns/dns_sd/wscript
+++ b/src/clients/mdns/dns_sd/wscript
@@ -21,10 +21,18 @@ def configure(conf):
   if Utils.unversioned_sys_platform() == "darwin":
     return
 
+  fragment = """
+  #include <dns_sd.h>
+  int main(void) {
+      DNSServiceRegister(0,0,0,0,0,0,0,0,0,0,0,0);
+      return 0;
+  }
+  """
+
   conf.check_cc(
           lib="dns_sd",
           header_name="dns_sd.h",
-          function_name="DNSServiceRegister",
+          fragment=fragment,
           uselib_store="dnssd"
           )
 

--- a/src/clients/medialib-updater/wscript
+++ b/src/clients/medialib-updater/wscript
@@ -21,7 +21,14 @@ def configure(conf):
     conf.check_cfg(package="gio-2.0", uselib_store='gio2',
             args="--cflags --libs")
 
-    conf.check_cc(function_name="g_file_query_file_type",
+    fragment = """
+    #include <gio/gio.h>
+    int main(void) {
+        g_file_query_file_type(0,0,0);
+        return 0;
+    }
+    """
+    conf.check_cc(fragment=fragment,
             header_name="gio/gio.h", uselib="gio2", mandatory=False)
 
 

--- a/src/clients/nycli/wscript
+++ b/src/clients/nycli/wscript
@@ -57,10 +57,19 @@ def configure(conf):
 
     conf.check_cc(header_name=rl_headers)
 
+    fragment = """
+    #include <stdio.h>
+    #include <readline/readline.h>
+    int main(void) {
+        rl_filename_dequoting_function(0, 0);
+        return 0;
+    }
+    """
+
     # first try just linking against libreadline
     try:
         conf.check_cc(lib="readline", header_name=rl_headers,
-                function_name='rl_filename_dequoting_function',
+                fragment=fragment,
                 uselib_store="readline", uselib="glib2")
     except Errors.ConfigurationError:
         pass
@@ -70,7 +79,7 @@ def configure(conf):
     # then try ncurses
     conf.check_cc(lib="ncurses", uselib_store="readline_ncurses")
     conf.check_cc(lib="readline", header_name=rl_headers,
-            function_name='rl_filename_dequoting_function',
+            fragment=fragment,
             uselib_store="readline", uselib="glib2 readline_ncurses")
 
 

--- a/src/lib/xmmsutils/wscript
+++ b/src/lib/xmmsutils/wscript
@@ -39,10 +39,17 @@ def configure(conf):
         conf.env.util_impl = 'win32'
     else:
         conf.env.util_impl = 'unix'
+
+        nanosleep_fragment = """
+        #include <time.h>
+        int main(void) {
+            return nanosleep(0,0);
+        }
+        """
         try:
-            conf.check_cc(function_name="nanosleep", header_name="time.h")
+            conf.check_cc(fragment=nanosleep_fragment, header_name="time.h")
         except Errors.ConfigurationError:
-            conf.check_cc(function_name="nanosleep", header_name="time.h",
+            conf.check_cc(fragment=nanosleep_fragment, header_name="time.h",
                     lib="rt", uselib_store="rt")
     return True
 

--- a/src/lib/xmmsvisualization/wscript
+++ b/src/lib/xmmsvisualization/wscript
@@ -24,7 +24,13 @@ def build(bld):
 
 def configure(conf):
     # Check for the modf function in the math lib
-    conf.check_cc(function_name="modf", header_name="math.h",
+    modf_fragment = """
+    #include <math.h>
+    int main(void) {
+        return modf(0.0, 0);
+    }
+    """
+    conf.check_cc(fragment=modf_fragment, header_name="math.h",
             lib="m", uselib_store="math")
     return True
 

--- a/src/plugins/curl/wscript
+++ b/src/plugins/curl/wscript
@@ -16,7 +16,14 @@ def plugin_configure(conf):
     # This is a function this plugin uses and that was added to curl in
     # version 7.12.0. We cannot check for the curl version as curl-config
     # did not support version tests before version 7.15.0
-    conf.check_cc(function_name="curl_multi_strerror",
+    fragment = """
+    #include <curl/curl.h>
+    int main(void) {
+        return curl_multi_strerror(0) != 0;
+    }
+    """
+
+    conf.check_cc(fragment=fragment,
             header_name="curl/curl.h", uselib="curl")
 
 configure, build = plugin('curl', configure=plugin_configure,

--- a/src/plugins/file/wscript
+++ b/src/plugins/file/wscript
@@ -4,9 +4,27 @@ def plugin_build(bld, obj):
     obj.source.append('browse/fstatat.c')
 
 def plugin_configure(conf):
-    conf.check_cc(function_name='fstatat', header_name=['fcntl.h','sys/stat.h'],
+    fstatat_fragment = """
+    #include <fcntl.h>
+    #include <sys/stat.h>
+    int main(void) {
+        struct stat s;
+        return fstatat(0,"path",&s,0);
+    }
+    """
+    conf.check_cc(fragment=fstatat_fragment, header_name=['fcntl.h','sys/stat.h'],
             defines=['_ATFILE_SOURCE=1'])
-    conf.check_cc(function_name='dirfd', header_name=['dirent.h','sys/types.h'])
+
+    dirfd_fragment = """
+    #include <dirent.h>
+    #include <sys/types.h>
+    int main(void) {
+        DIR * d;
+        d = opendir("/");
+        return dirfd(d);
+    }
+    """
+    conf.check_cc(fragment=dirfd_fragment, header_name=['dirent.h','sys/types.h'])
 
 configure, build = plugin("file",
         configure=plugin_configure, build=plugin_build,

--- a/src/xmms/wscript
+++ b/src/xmms/wscript
@@ -175,7 +175,13 @@ def get_statfs_impl(conf):
 # Get the implementation variant for the localtime_r function.
 def get_localtime_impl(conf):
     try:
-        conf.check_cc(function_name='localtime_r', header_name='time.h')
+        localtime_r_fragment = """
+        #include <time.h>
+        int main(void) {
+            return localtime_r(0, 0) != 0;
+        }
+        """
+        conf.check_cc(fragment=localtime_r_fragment, header_name='time.h')
     except Errors.ConfigurationError:
         return 'dummy'
     else:
@@ -193,7 +199,13 @@ def get_visualization_impl(conf):
         return 'dummy'
 
     try:
-        conf.check_cc(function_name='semctl',
+        semctl_fragment = """
+        #include <sys/sem.h>
+        int main(void) {
+            return semctl(0,0,0,0);
+        }
+        """
+        conf.check_cc(fragment=semctl_fragment,
                       header_name=['sys/types.h','sys/ipc.h','sys/sem.h'])
     except:
         have_semctl = False
@@ -216,7 +228,13 @@ def configure(conf):
             uselib_store='gmodule2', args='--cflags --libs')
 
     # Check for the sin function in the math lib
-    conf.check_cc(lib='m', function_name='sin', header_name='math.h',
+    sin_fragment = """
+    #include <math.h>
+    int main(void) {
+        return sin(0.5);
+    }
+    """
+    conf.check_cc(lib='m', fragment=sin_fragment, header_name='math.h',
                   uselib_store="math")
 
     conf.env.compat_impl = get_compat_impl(conf)

--- a/wscript
+++ b/wscript
@@ -450,7 +450,13 @@ def configure(conf):
         conf.env.explicit_install_name = False
 
     if Utils.unversioned_sys_platform() == 'sunos':
-        conf.check_cc(function_name='socket', lib='socket', header_name='sys/socket.h', uselib_store='socket')
+        socket_fragment = """
+        #include <sys/socket.h>
+        int main(void) {
+          return socket(0,0,0);
+        }
+        """
+        conf.check_cc(fragment=socket_fragment, lib='socket', header_name='sys/socket.h', uselib_store='socket')
         conf.env.append_unique('CFLAGS', '-D_POSIX_PTHREAD_SEMANTICS')
         conf.env.append_unique('CFLAGS', '-D_REENTRANT')
         conf.env.append_unique('CFLAGS', '-std=gnu99')


### PR DESCRIPTION
Recent waf versions dropped support for 'check_cc(function_name=)'
which causes errors and warning during ./waf configure:

    Invalid argument 'function_name' in test

(Done as part of https://gitlab.com/ita1024/waf/-/issues/2204).

The change switcher to more verbose (and more robust)
'check_cc(fragment=' equivalent.