### PR TITLE
OTHER: support ffmpeg5

### DIFF
--- a/src/plugins/avcodec/wscript
+++ b/src/plugins/avcodec/wscript
@@ -1,7 +1,7 @@
 from waftools.plugin import plugin
 
 ## Code fragments for configuration
-avcodec_decode_audio4_fragment = """
+avcodec_send_packet_fragment = """
 #ifdef HAVE_LIBAVCODEC_AVCODEC_H
 # include "libavcodec/avcodec.h"
 #else
@@ -9,11 +9,9 @@ avcodec_decode_audio4_fragment = """
 #endif
 int main(void) {
     AVCodecContext *ctx;
-    AVFrame *frame;
-    int got_frame;
     AVPacket *pkt;
 
-    avcodec_decode_audio4 (ctx, frame, &got_frame, pkt);
+    avcodec_send_packet (ctx, pkt);
 
     return 0;
 }
@@ -40,12 +38,12 @@ def plugin_configure(conf):
     conf.check_cc(header_name="avcodec.h", uselib="avcodec", type="cshlib", mandatory=False)
     conf.check_cc(header_name="libavcodec/avcodec.h", uselib="avcodec", type="cshlib", mandatory=False)
 
-    # mandatory function avcodec_decode_audio4 available since
-    # * ffmpeg: commit e4de716, lavc 53.40.0, release 0.9
-    # * libav: commit 0eea212, lavc 53.25.0, release 0.8
-    conf.check_cc(fragment=avcodec_decode_audio4_fragment, uselib="avcodec",
-                  uselib_store="avcodec_decode_audio4",
-                  msg="Checking for function avcodec_decode_audio4", mandatory=True)
+    # mandatory function avcodec_send_packet available since
+    # * ffmpeg: commit 7fc329e, lavc 57.37.100, release 3.1
+    # * libav: commit 05f6670, lavc 57.16.0, release 12
+    conf.check_cc(fragment=avcodec_send_packet_fragment, uselib="avcodec",
+                  uselib_store="avcodec_send_packet",
+                  msg="Checking for function avcodec_send_packet", mandatory=True)
 
     # non-mandatory function avcodec_free_frame since
     # * ffmpeg: commit 46a3595, lavc 54.59.100, release 1.0


### PR DESCRIPTION
I'm not really familiar with ffmpeg or xmms2 codebase but I wrote this quickly given some other ffmpeg5 patches going around are entirely wrong (they assume avcodec_receive_frame returns bytes_read, but it doesn't and results in an eternally looping frame even with ffmpeg4 -- instead it needs to be called multiple times until packet EOF). Not to say this one may not have issues too, haven't tested much beside trying some .tta and .wma.

Patch been used in Gentoo since March 16 (downstream [bug #834398](https://bugs.gentoo.org/834398)), but we only need to support recent ffmpeg4+5 there and I couldn't say if still want to support old ffmpeg / libav.

If any changes are wanted I'd prefer someone who knows better took over, thanks.