### PR TITLE
Python client's PropDict class doesn't handle map objects correctly

### DIFF
--- a/src/clients/lib/python/xmmsclient/propdict.py
+++ b/src/clients/lib/python/xmmsclient/propdict.py
@@ -8,7 +8,9 @@ except NameError:
 class PropDict(dict):
 	def __init__(self, srcs):
 		dict.__init__(self)
-		self._sources = srcs
+		self._sources = list(srcs)
+		if len(self._sources) == 0:
+			self._sources = ['*']
 
 	def set_source_preference(self, sources):
 		"""
@@ -56,6 +58,9 @@ class PropDict(dict):
 	def _set_sources(self, val):
 		if isinstance(val, basestring):
 			raise TypeError("Need a sequence of sources")
+		val = list(val)
+		if len(val) == 0:
+			val = ['*']
 		for i in val:
 			if not isinstance(i, basestring):
 				raise TypeError("Sources need to be strings")


### PR DESCRIPTION
The PropDict class (which inherits from dict) assumes that the given "srcs" are a list.  However, these srcs are created using map(), which in python2 returned a list, but in python3 returns a map object.  This wouldn't be too bad, except unfortunately, the func in the map isn't idempotent, which means that iterating self._sources multiple times leads to bizarre results, ie. the key is found the first time, but not subsequent times.  This breaks clients that happen to look up multiple keys (or keys multiple times).

Since the list of sources is always small (AFAIK), the simplest solution is to just materialise it back into being a list at init time.