### PR TITLE
Make GitHub Dependabot keep GitHub Actions up to date

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+
+  - package-ecosystem: "github-actions"
+    commit-message:
+      include: "scope"
+      prefix: "Actions"
+    directory: "/"
+    labels:
+      - "enhancement"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Makes GitHub Dependabot create pull requests like https://github.com/hartwork/git-delete-merged-branches/pull/110 to keep GitHub Actions up to date. Follow-up to https://github.com/xmms2/xmms2-devel/pull/17#issuecomment-1515329114 .

CC @trofi 