### PR TITLE
Fix typos in src/xmms

### DIFF
--- a/src/xmms/collsync.c
+++ b/src/xmms/collsync.c
@@ -249,7 +249,7 @@ xmms_coll_sync_sorry_to_revert_your_collections (const gchar *path)
 
 cleanup:
 	if (success == FALSE) {
-		xmms_log_error ("Could not ressurect collections, sorry...");
+		xmms_log_error ("Could not resurrect collections, sorry...");
 		if (error != NULL) {
 			XMMS_DBG ("%s", error->message);
 		}

--- a/src/xmms/converter.head.c
+++ b/src/xmms/converter.head.c
@@ -209,7 +209,7 @@ recalculate_resampler (xmms_sample_converter_t *conv, guint from, guint to)
 
 
 /**
- * do the actual converstion between two audio formats.
+ * do the actual conversion between two audio formats.
  */
 void
 xmms_sample_convert (xmms_sample_converter_t *conv, xmms_sample_t *in, guint len, xmms_sample_t **out, guint *outlen)

--- a/src/xmms/courier.c
+++ b/src/xmms/courier.c
@@ -177,7 +177,7 @@ xmms_courier_pending_pool_destroy (xmms_courier_pending_pool_t *pending)
  * @param courier the courier object
  * @param reply_policy the reply policy expected by the sender
  * @param c2c_msg a c2c-message (with at least msgid, sender, destination)
- * @param is_reply whether a reply (intead of a normal message) is to be sent
+ * @param is_reply whether a reply (instead of a normal message) is to be sent
  * @param dcookie in case is_reply is TRUE, the cookie associated with the
  *               message that is being replied to in the destination client
  * @param scookie in case is_reply is TRUE, the cookie associated with the

--- a/src/xmms/main.c
+++ b/src/xmms/main.c
@@ -84,7 +84,7 @@ static void spawn_script_setup (gpointer data);
 
 
 /**
- * Main object, when this is unreffed, XMMS2 is quiting.
+ * Main object, when this is unreffed, XMMS2 is quitting.
  */
 struct xmms_main_St {
 	xmms_object_t object;
@@ -635,7 +635,7 @@ main (int argc, char **argv)
 
 	if (!ipcpath) {
 		/*
-		 * if not ipcpath is specifed on the cmd line we
+		 * if not ipcpath is specified on the cmd line we
 		 * grab it from the config
 		 */
 		ipcpath = xmms_config_property_get_string (cv);

--- a/src/xmms/medialib_query.c
+++ b/src/xmms/medialib_query.c
@@ -961,7 +961,7 @@ collection_to_condition (xmms_medialib_session_t *session, xmmsv_t *coll,
  *
  * @param coll The collection to use when querying
  * @param fetch Information on what is being fetched
- * @return An S4 resultset correspoding to the entires in the
+ * @return An S4 resultset corresponding to the entries in the
  * medialib matching the collection.
  * Must be free with s4_resultset_free
  */

--- a/src/xmms/object.c
+++ b/src/xmms/object.c
@@ -98,11 +98,11 @@ compare_signal_key (gconstpointer a, gconstpointer b)
   * You can connect many handlers to the same signal as long as
   * the handler address is unique.
   *
-  * @todo fix the need for a unique handler adress?
+  * @todo fix the need for a unique handler address?
   *
   * @param object the object that will emit the signal
   * @param signalid the signalid to connect to @sa signal_xmms.h
-  * @param handler the Callback function to be called when signal is emited.
+  * @param handler the Callback function to be called when signal is emitted.
   * @param userdata data to the callback function
   */
 

--- a/src/xmms/output.c
+++ b/src/xmms/output.c
@@ -139,7 +139,7 @@ struct xmms_output_St {
 	xmms_stream_type_t *format;
 
 	/**
-	 * Number of bytes totaly written to output driver,
+	 * Number of bytes totally written to output driver,
 	 * this is only for statistics...
 	 */
 	guint64 bytes_written;
@@ -971,7 +971,7 @@ xmms_output_new (xmms_output_plugin_t *plugin, xmms_playlist_t *playlist, xmms_m
 			xmms_log_error ("Could not initialize output plugin");
 		}
 	} else {
-		xmms_log_error ("initalized output without a plugin, please fix!");
+		xmms_log_error ("initialized output without a plugin, please fix!");
 	}
 
 

--- a/src/xmms/playlist.c
+++ b/src/xmms/playlist.c
@@ -707,7 +707,7 @@ xmms_playlist_client_insert_url (xmms_playlist_t *playlist, const gchar *plname,
 /**
   * Convenient function for inserting a directory at a given position
   * in the playlist, It will dive down the URL you feed it and
-  * recursivly insert all files.
+  * recursively insert all files.
   *
   * @param playlist the playlist to add it URL to.
   * @param plname the name of the playlist to modify.
@@ -868,7 +868,7 @@ xmms_playlist_client_add_url (xmms_playlist_t *playlist, const gchar *plname,
 
 /**
   * Convenient function for adding a directory to the playlist,
-  * It will dive down the URL you feed it and recursivly add
+  * It will dive down the URL you feed it and recursively add
   * all files there.
   *
   * @param playlist the playlist to add it URL to.

--- a/src/xmms/ringbuf.c
+++ b/src/xmms/ringbuf.c
@@ -216,9 +216,9 @@ read_bytes (xmms_ringbuf_t *ringbuf, guint8 *data, guint len)
  * ensure that you get as much data as you want.
  *
  * @param ringbuf Buffer to read from
- * @param data Allocated buffer where the readed data will end up
+ * @param data Allocated buffer where the read data will end up
  * @param len number of bytes to read
- * @returns number of bytes that acutally was read.
+ * @returns number of bytes that actually was read.
  */
 guint
 xmms_ringbuf_read (xmms_ringbuf_t *ringbuf, gpointer data, guint len)

--- a/src/xmms/utils.c
+++ b/src/xmms/utils.c
@@ -157,7 +157,7 @@ xmms_natcmp (const gchar *str1, const gchar *str2)
  * Case insensitive version of g_str_equal.
  * @param v1 first string
  * @param v2 second string
- * @return TRUE if first string equals the seconds tring, otherwise FALSE
+ * @return TRUE if first string equals the second string, otherwise FALSE
  */
 gboolean
 xmms_strcase_equal (gconstpointer v1, gconstpointer v2)

--- a/src/xmms/visualization/format.c
+++ b/src/xmms/visualization/format.c
@@ -108,7 +108,7 @@ fft (short *samples, gfloat *spec)
 }
 
 /**
- * Calcualte the FFT on the decoded data buffer.
+ * Calculate the FFT on the decoded data buffer.
  */
 static short
 fill_buffer_fft (int16_t* dest, int size, short *src)

--- a/src/xmms/visualization/object.c
+++ b/src/xmms/visualization/object.c
@@ -128,7 +128,7 @@ xmms_visualization_new (xmms_output_t *output)
 }
 
 /**
- * Free all resoures used by visualization module.
+ * Free all resources used by visualization module.
  * TODO: Fill this in properly, unregister etc!
  */
 

--- a/src/xmms/visualization/unixshm.c
+++ b/src/xmms/visualization/unixshm.c
@@ -97,7 +97,7 @@ void cleanup_shm (xmmsc_vis_unixshm_t *t)
 }
 
 /**
- * Decrements the server's semaphor (to write the next chunk)
+ * Decrements the server's semaphore (to write the next chunk)
  */
 static gboolean
 decrement_server (xmmsc_vis_unixshm_t *t)
@@ -120,7 +120,7 @@ decrement_server (xmmsc_vis_unixshm_t *t)
 }
 
 /**
- * Increments the client's semaphor (after a chunk was written)
+ * Increments the client's semaphore (after a chunk was written)
  */
 static void
 increment_client (xmmsc_vis_unixshm_t *t)


### PR DESCRIPTION
Fix a variety of typos in the src/xmms subdirectory