### PR TITLE
clients/nycli/utils.c: Fix buffer overflow

### DIFF
--- a/src/clients/nycli/utils.c
+++ b/src/clients/nycli/utils.c
@@ -427,7 +427,7 @@ encode_url (gchar *url)
 gchar *
 format_url (const gchar *path, GFileTest test)
 {
-	gchar rpath[XMMS_PATH_MAX];
+	gchar rpath[PATH_MAX];
 	const gchar *p;
 	gchar *url;
 


### PR DESCRIPTION
format_url() is only assigning 255 bytes for the rpath, but the path will be expanded by realpath() which can return a sring up to a maximum of PATH_MAX bytes. And, so as a result, if long path names are used or while creating playlists with multiple files we get a coredump with the error:

*** buffer overflow detected ***: terminated
Aborted (core dumped)

Lets use PATH_MAX for rpath length so that we have buffer for the maximum return from realpath().

Reported in Ubuntu at https://bugs.launchpad.net/ubuntu/+source/xmms2/+bug/2018449