### PR TITLE
avcodec: replace deprecated avcodec_close by avcodec_free_context (ffmpeg8)

### DIFF
--- a/src/plugins/avcodec/avcodec.c
+++ b/src/plugins/avcodec/avcodec.c
@@ -130,8 +130,7 @@ xmms_avcodec_destroy (xmms_xform_t *xform)
 	data = xmms_xform_private_data_get (xform);
 	g_return_if_fail (data);
 
-	avcodec_close (data->codecctx);
-	av_free (data->codecctx);
+	avcodec_free_context (&(data->codecctx));
 	av_frame_free (&data->read_out_frame);
 
 	g_string_free (data->outbuf, TRUE);
@@ -251,7 +250,6 @@ xmms_avcodec_init (xmms_xform_t *xform)
 			g_string_insert_len (data->outbuf, 0, buf, ret);
 		} else {
 			XMMS_DBG ("First read failed, codec is not working...");
-			avcodec_close (data->codecctx);
 			goto err;
 		}
 	}
@@ -260,7 +258,6 @@ xmms_avcodec_init (xmms_xform_t *xform)
 	data->channels = XMMS2_AVCODEC_CHANNEL_FIELD(data->codecctx);
 	data->sampleformat = xmms_avcodec_translate_sample_format (data->codecctx->sample_fmt);
 	if (data->sampleformat == XMMS_SAMPLE_FORMAT_UNKNOWN) {
-		avcodec_close (data->codecctx);
 		goto err;
 	}
 
@@ -284,7 +281,7 @@ xmms_avcodec_init (xmms_xform_t *xform)
 
 err:
 	if (data->codecctx) {
-		av_free (data->codecctx);
+		avcodec_free_context (&(data->codecctx));
 	}
 	if (data->read_out_frame) {
 		avcodec_free_frame (&data->read_out_frame);


### PR DESCRIPTION
ffmpeg-8 is removing it, from avcodec.h:
```
 * @deprecated Do not use this function. Use avcodec_free_context() to destroy a
 * codec context (either open or closed). Opening and closing a codec context
 * multiple times is not supported anymore -- use multiple codec contexts
 * instead.
```
avcodec_free_context does the work of avcodec_close+av_free. Haven't checked when free_context was first introduced but it has existed "at least" since ffmpeg-4 and shouldn't cause problems.

Not looked at this too closely nor know ffmpeg/xmms2 well, so possible I've overlooked/misunderstood something (please take this over if know better), but I was at least able to play a test.wma (uses avcodec) successfully with this commit + a ffmpeg-8 snapshot at 13b161cd24.