### PR TITLE
fix double free with apefile

### DIFF
--- a/src/plugins/avcodec/avcodec.c
+++ b/src/plugins/avcodec/avcodec.c
@@ -134,8 +134,8 @@ xmms_avcodec_destroy (xmms_xform_t *xform)
 	av_frame_free (&data->read_out_frame);
 
 	g_string_free (data->outbuf, TRUE);
+	/* extradata freed by avcodec_free_context() */
 	g_free (data->buffer);
-	g_free (data->extradata);
 	g_free (data);
 }
 


### PR DESCRIPTION
fix double free with apefile, extradata is used by decoder_init and is owned and freed by ffmpeg